### PR TITLE
Add missing tests for commit 75e49fe

### DIFF
--- a/ckanext/datasetversions/helpers.py
+++ b/ckanext/datasetversions/helpers.py
@@ -11,3 +11,25 @@ def is_old(package):
         return names.index(package['name']) != 0
     except ValueError:
         return False
+
+
+def _get_context(context):
+    """An internal context generator. Accepts a CKAN context.
+
+    CKAN's internals put various things into the context which
+    makes reusing it for multiple API calls inadvisable. This
+    function adds more fine grain control on the context from
+    our plugin logic side.
+    """
+    new_context = {
+        'model': context['model'],
+        'session': context['session'],
+        'user': context.get('user'),
+        'ignore_auth': context.get('ignore_auth', False),
+        'use_cache': context.get('use_cache', False),
+    }
+
+    if 'validate' in context:
+        new_context['validate'] = context['validate']
+
+    return new_context

--- a/ckanext/datasetversions/helpers.py
+++ b/ckanext/datasetversions/helpers.py
@@ -13,7 +13,7 @@ def is_old(package):
         return False
 
 
-def _get_context(context):
+def get_context(context):
     """An internal context generator. Accepts a CKAN context.
 
     CKAN's internals put various things into the context which

--- a/ckanext/datasetversions/logic/action/create.py
+++ b/ckanext/datasetversions/logic/action/create.py
@@ -2,7 +2,7 @@ import ckan.logic as logic
 from ckan.logic.action.get import package_show as ckan_package_show
 from ckan.plugins import toolkit
 
-from ckanext.datasetversions.helpers import _get_context
+from ckanext.datasetversions.helpers import get_context
 
 
 def dataset_version_create(context, data_dict):
@@ -27,7 +27,7 @@ def dataset_version_create(context, data_dict):
     )
 
     toolkit.get_action('package_relationship_create')(
-        _get_context(context), {
+        get_context(context), {
             'subject': id,
             'object': parent['id'],
             'type': 'child_of',
@@ -38,9 +38,9 @@ def dataset_version_create(context, data_dict):
 def _get_or_create_parent_dataset(context, data_dict):
     try:
         dataset = ckan_package_show(
-            _get_context(context), {'id': data_dict['name']})
+            get_context(context), {'id': data_dict['name']})
     except (logic.NotFound):
         dataset = toolkit.get_action('package_create')(
-            _get_context(context), data_dict)
+            get_context(context), data_dict)
 
     return dataset

--- a/ckanext/datasetversions/logic/action/create.py
+++ b/ckanext/datasetversions/logic/action/create.py
@@ -2,6 +2,8 @@ import ckan.logic as logic
 from ckan.logic.action.get import package_show as ckan_package_show
 from ckan.plugins import toolkit
 
+from ckanext.datasetversions.helpers import _get_context
+
 
 def dataset_version_create(context, data_dict):
     id = data_dict.get('id')
@@ -42,12 +44,3 @@ def _get_or_create_parent_dataset(context, data_dict):
             _get_context(context), data_dict)
 
     return dataset
-
-
-def _get_context(context):
-    return {
-        'model': context['model'],
-        'session': context['session'],
-        'user': context['user'],
-        'ignore_auth': context.get('ignore_auth', False)
-    }

--- a/ckanext/datasetversions/logic/action/get.py
+++ b/ckanext/datasetversions/logic/action/get.py
@@ -3,7 +3,7 @@ from ckan.plugins import toolkit
 import ckan.logic as logic
 from ckan.logic.action.get import package_show as ckan_package_show
 
-from ckanext.datasetversions.helpers import _get_context
+from ckanext.datasetversions.helpers import get_context
 
 
 @toolkit.side_effect_free
@@ -23,19 +23,19 @@ def package_show(context, data_dict):
     version_to_display = requested_dataset
 
     parent_names = _get_parent_dataset_names(
-        _get_context(context), requested_dataset['id'])
+        get_context(context), requested_dataset['id'])
 
     if len(parent_names) > 0:
         base_name = parent_names[0]
         dataset_type = DatasetType.specific_version
         all_version_names = _get_child_dataset_names(
-            _get_context(context), base_name)
+            get_context(context), base_name)
     else:
         # Requesting the latest version or an unversioned dataset
         base_name = requested_dataset['name']
 
         all_version_names = _get_child_dataset_names(
-            _get_context(context), base_name)
+            get_context(context), base_name)
 
         if len(all_version_names) > 0:
             dataset_type = DatasetType.latest_version
@@ -43,7 +43,7 @@ def package_show(context, data_dict):
             dataset_type = DatasetType.unversioned
 
     all_active_versions = _get_ordered_active_dataset_versions(
-        _get_context(context),
+        get_context(context),
         data_dict.copy(),  # Will get modified so make a copy
         all_version_names)
 
@@ -55,7 +55,7 @@ def package_show(context, data_dict):
     if dataset_type in (DatasetType.unversioned, DatasetType.specific_version):
         # Do default CKAN authentication
         context['ignore_auth'] = ignore_auth
-        logic.check_access('package_show', _get_context(context), data_dict)
+        logic.check_access('package_show', get_context(context), data_dict)
 
     version_to_display['_versions'] = _get_version_names_and_urls(
         all_active_versions, base_name)

--- a/ckanext/datasetversions/logic/action/get.py
+++ b/ckanext/datasetversions/logic/action/get.py
@@ -137,8 +137,13 @@ def _get_version(dataset):
 
 
 def _get_context(context):
-    # Unfortunately CKAN puts things in the context, which
-    # makes reusing it for multiple API calls inadvisable
+    """An internal context generator. Accepts a CKAN context.
+
+    CKAN's internals put various things into the context which
+    makes reusing it for multiple API calls inadvisable. This
+    function adds more fine grain control on the context from
+    our plugin logic side.
+    """
     new_context = {
         'model': context['model'],
         'session': context['session'],

--- a/ckanext/datasetversions/logic/action/get.py
+++ b/ckanext/datasetversions/logic/action/get.py
@@ -3,6 +3,8 @@ from ckan.plugins import toolkit
 import ckan.logic as logic
 from ckan.logic.action.get import package_show as ckan_package_show
 
+from ckanext.datasetversions.helpers import _get_context
+
 
 @toolkit.side_effect_free
 def package_show(context, data_dict):
@@ -134,25 +136,3 @@ def _get_version(dataset):
         version_number = 0
 
     return version_number
-
-
-def _get_context(context):
-    """An internal context generator. Accepts a CKAN context.
-
-    CKAN's internals put various things into the context which
-    makes reusing it for multiple API calls inadvisable. This
-    function adds more fine grain control on the context from
-    our plugin logic side.
-    """
-    new_context = {
-        'model': context['model'],
-        'session': context['session'],
-        'user': context.get('user'),
-        'ignore_auth': context.get('ignore_auth', False),
-        'use_cache': context.get('use_cache', False),
-    }
-
-    if 'validate' in context:
-        new_context['validate'] = context['validate']
-
-    return new_context

--- a/ckanext/datasetversions/plugin.py
+++ b/ckanext/datasetversions/plugin.py
@@ -130,4 +130,5 @@ class DatasetversionsPlugin(plugins.SingletonPlugin):
         return {
             'datasetversions_list': helpers.list,
             'datasetversions_is_old': helpers.is_old,
+            'datasetversions_get_context': helpers.get_context,
         }

--- a/ckanext/datasetversions/tests/test_helpers.py
+++ b/ckanext/datasetversions/tests/test_helpers.py
@@ -39,3 +39,22 @@ class TestHelpers(unittest.TestCase):
         package = {'name': 'v3'}
 
         self.assertFalse(self._get_helper('datasetversions_is_old')(package))
+
+    def test_get_context_threads_desired_values(self):
+        default_keys = ['model', 'session', 'user', 'ignore_auth', 'use_cache']
+        minimal_context = {'model': 'foo', 'session': 'bar'}
+        get_context = self._get_helper('datasetversions_get_context')
+
+        result = get_context(minimal_context)
+        self.assertEqual(sorted(result.keys()), sorted(default_keys))
+
+        should_val = dict(minimal_context.items(), **{'validate': True})
+        result = get_context(should_val)
+        self.assertTrue(result['validate'])
+
+        shouldnt_val = dict(minimal_context.items(), **{'validate': False})
+        result = get_context(shouldnt_val)
+        self.assertFalse(result['validate'])
+
+        result = get_context(shouldnt_val)
+        self.assertIsNone(result['user'])


### PR DESCRIPTION
The following happens in this change set:
  - [x] `_get_context` moves to `helpers.get_context`
  - [x] https://github.com/aptivate/ckanext-datasetversions/commit/75e49fe08ae8946bcc1fc2614a6b66cacea824ac is tested

Finally getting a hold on our CKAN deployment.