### PR TITLE
Add url field to the API that points to the web UI of the dataset

### DIFF
--- a/ckanext/datasetversions/logic/action/get.py
+++ b/ckanext/datasetversions/logic/action/get.py
@@ -80,7 +80,7 @@ def package_show(context, data_dict):
 @toolkit.side_effect_free
 def package_search(context, data_dict):
     """
-    Override to add urls that point to the web UI for each dagtaset
+    Override to add urls that point to the web UI for each dataset
     """
     data = ckan_package_search(context, data_dict)
 

--- a/ckanext/datasetversions/logic/action/get.py
+++ b/ckanext/datasetversions/logic/action/get.py
@@ -1,7 +1,9 @@
 from ckan.plugins import toolkit
+from ckan.lib import helpers as core_helpers
 
 import ckan.logic as logic
 from ckan.logic.action.get import package_show as ckan_package_show
+from ckan.logic.action.get import package_search as ckan_package_search
 
 
 @toolkit.side_effect_free
@@ -17,6 +19,12 @@ def package_show(context, data_dict):
 
     # Get the dataset we actually asked for
     requested_dataset = ckan_package_show(context, data_dict)
+
+    # Add field with URL to the Api that points to the web UI for datasets
+    requested_dataset['url'] = core_helpers.url_for(controller='package',
+                                                    action='read',
+                                                    id=requested_dataset['name'],
+                                                    qualified=True)
 
     version_to_display = requested_dataset
 
@@ -65,6 +73,23 @@ def package_show(context, data_dict):
     version_to_display.pop('relationships_as_object', False)
 
     return version_to_display
+
+
+@toolkit.side_effect_free
+def package_search(context, data_dict):
+    """
+    Override to add urls that point to the web UI for each dagtaset
+    """
+    data = ckan_package_search(context, data_dict)
+
+    for result in data.get('results'):
+        # Add field with URL to the Api that points to the web UI for datasets
+        result['url'] = core_helpers.url_for(controller='package',
+                                             action='read',
+                                             id=result['name'],
+                                             qualified=True)
+
+    return data
 
 
 def _get_version_names_and_urls(all_active_versions, base_name):

--- a/ckanext/datasetversions/plugin.py
+++ b/ckanext/datasetversions/plugin.py
@@ -21,6 +21,8 @@ class DatasetversionsPlugin(plugins.SingletonPlugin):
             ckanext.datasetversions.logic.action.get.package_show,
             'dataset_version_create':
             ckanext.datasetversions.logic.action.create.dataset_version_create,
+            'package_search':
+            ckanext.datasetversions.logic.action.get.package_search
         }
 
     # IConfigurer


### PR DESCRIPTION
- Changed the default url field in the CKAN API to point from default "URL for the dataset’s source" (null in the case of mapaction) to the web UI of the dataset (MDR2-24 jira task)